### PR TITLE
Add OpenBlas to CMAKE library path

### DIFF
--- a/install-luajit+torch
+++ b/install-luajit+torch
@@ -24,7 +24,7 @@ echo "Installing Torch into: $PREFIX"
 
 # On Linux, export Gfortran's path (this does something only if OpenBLAS is found)
 if [[ `uname` == 'Linux' ]]; then
-    export CMAKE_LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu:/usr/lib/gcc/x86_64-linux-gnu/4.6:$CMAKE_LIBRARY_PATH
+    export CMAKE_LIBRARY_PATH=/opt/OpenBLAS/include:/opt/OpenBLAS/lib:/usr/lib/gcc/x86_64-linux-gnu:/usr/lib/gcc/x86_64-linux-gnu/4.6:$CMAKE_LIBRARY_PATH
 fi
 
 # Build and install Torch7


### PR DESCRIPTION
I noticed that CMAKE used the "generic" BLAS implementation of Ubuntu, which is slow. Adding the OpenBlas installation location to the CMAKE library path fixed this. 

An open question remains if the `/usr/lib/gcc/x86_64-linux-gnu/4.6` part is correct. I edited it to 4.8, as I don't have 4.6 installed, but I am not sure if that's necessary so I didn't include it in this PR.
