### PR TITLE
removed gnuplot lua dependency, added xquartz install

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -22,8 +22,10 @@ if [[ `uname` == 'Darwin' ]]; then
     brew install git readline cmake wget qt
     brew install libjpeg imagemagick zeromq 
     brew link readline --force
+    brew install caskroom/cask/brew-cask
+    brew cask install xquartz
     brew remove gnuplot
-    brew install gnuplot --wx --cairo --pdf --with-x
+    brew install gnuplot --wx --cairo --pdf --with-x --nolua
 
 elif [[ `uname` == 'Linux' ]]; then
     # Aptitude?


### PR DESCRIPTION
Tested out ezinstall on a fresh OSX machine and ran into a couple of issues.
- XQuartz isn't installed by default, so gnuplot fails. This fixes that issue.
- Also, gnuplot depends on lua (so brew lua was getting installed), so added --nolua flag so that this wouldnt happen.
