### PR TITLE
Warning to archlinux users

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -35,6 +35,22 @@ install_openblas_AUR() {
     makepkg -csi
 }
 
+chekupdates_archlinux() {
+    # checks if archlinux is up to date
+    if [[ -n $(checkupdates) ]]; then
+        echo "It seems that your system is not up to date."
+        echo "It is recommended to update your system before going any further."
+        read -p "Continue installation ? [y/N] " yn
+            case $yn in
+                Y|y ) echo "Continuing...";;
+                N|n ) ;;
+                * ) echo "Installation aborted."
+                    echo "Relauch this script after updating your system with 'pacman -Syu'."
+                    exit 0
+            esac
+    fi
+}
+
 # Based on Platform:
 if [[ `uname` == 'Darwin' ]]; then
     # GCC?
@@ -136,16 +152,7 @@ elif [[ `uname` == 'Linux' ]]; then
 
     elif [[ $distribution == 'archlinux' ]]; then
         echo "Archlinux installation"
-        if [[ -n $(checkupdates) ]]; then
-            echo "It seems that your system is not up to date."
-            echo "It is recommended to update your system before going any further."
-            read -p "Continue installation ? [y/N] " yn
-                case $yn in
-                    Y|y ) echo "Continuing...";;
-                    N|n ) ;;
-                    * ) echo "Installation aborted."; echo "Relauch this script after updating your system with 'pacman -Syu'."; exit 0;
-                esac
-        fi
+        chekupdates_archlinux
         sudo pacman -S --quiet --noconfirm \
             cmake curl readline ncurses git \
             gnuplot unzip libjpeg-turbo libpng libpng \

--- a/install-deps
+++ b/install-deps
@@ -136,6 +136,16 @@ elif [[ `uname` == 'Linux' ]]; then
 
     elif [[ $distribution == 'archlinux' ]]; then
         echo "Archlinux installation"
+        if [[ -n $(checkupdates) ]]; then
+            echo "It seems that your system is not up to date."
+            echo "It is recommended to update your system before going any further."
+            read -p "Continue installation ? [y/N] " yn
+                case $yn in
+                    Y|y ) echo "Continuing...";;
+                    N|n ) ;;
+                    * ) echo "Installation aborted."; echo "Relauch this script after updating your system with 'pacman -Syu'."; exit 0;
+                esac
+        fi
         sudo pacman -S --quiet --noconfirm \
             cmake curl readline ncurses git \
             gnuplot unzip libjpeg-turbo libpng libpng \


### PR DESCRIPTION
Added a test for archlinux.
It only prompts the user if the system is not up to date. The check is made with


    checkupdate

which is a script bundled with pacman.

This script safely check differences between remote package list and packages currently installed on the system.

It is the "less worst" way I found, although it's not entirely satisfying, because if the only package which has remotely changed is one of those which are going to be installed (and is not yet present on the system), the change will not be detected, and it will fail anyway.
At least, I think it will prevent the great majority of the current failures.