### PR TITLE
only warn about iPython version if it exists. closes #52

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -213,9 +213,12 @@ else
     exit
 fi
 
-ipython_version=$(ipython --version|cut -f1 -d'.')
-if [[ $ipython_version != 2 && $ipython_version != 3 ]]; then {
-    echo 'WARNING: Your ipython version is too old.  Type "ipython --version" to see this.  Should be at least version 2'
+ipython_exists=$(command -v ipython)
+if [[ $ipython_exists ]]; then {
+    ipython_version=$(ipython --version|cut -f1 -d'.')
+    if [[ $ipython_version != 2 && $ipython_version != 3 ]]; then {
+        echo 'WARNING: Your ipython version is too old.  Type "ipython --version" to see this.  Should be at least version 2'
+    } fi
 } fi
 
 # Done.


### PR DESCRIPTION
This is not a bug or feature, but clarifies a small ambiguity for people who may be installing without iPython, and therefore not needing iTorch.