### PR TITLE
Improved OS detection for install-deps

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -86,6 +86,11 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         DIST_VERS=( $( cat /etc/redhat-release ) ) # make the file an array
         DISTRO="${DIST_VERS[0],,}" # get the first element and get lcase
         VERS="${DIST_VERS[2]}" # get the third element (version)
+    elif [[ -r /etc/lsb-release ]]; then
+        DIST_VERS="$( ( . /etc/lsb-release &>/dev/null
+                        echo "${DISTRIB_ID,,} $DISTRIB_RELEASE") )"
+        DISTRO="${DIST_VERS%% *}" # get our distro name
+        VERSION="${DIST_VERS##* }" # get our version number
     else # well, I'm out of ideas for now
         echo '==> Failed to determine distro and version.'
         exit 1

--- a/install-deps
+++ b/install-deps
@@ -76,10 +76,11 @@ if [[ `uname` == 'Darwin' ]]; then
 
 elif [[ "$(uname)" == 'Linux' ]]; then
 
-    DISTRO_VERSION="$( (source /etc/os-release &>/dev/null; echo "$ID VERSION_ID") )"
+    # this will get the required information without dirtying any env state
+    DIST_VERS="$((source /etc/os-release &>/dev/null; echo "$ID $VERSION_ID"))"
 
-    DISTRO="${DISTRO_VERSION%% *}" # get our distro name
-    VERSION="${DISTRO_VERSION## *}" # get our version number
+    DISTRO="${DIST_VERS%% *}" # get our distro name
+    VERSION="${DIST_VERS## *}" # get our version number
 
     # Detect fedora
     if [[ "$DISTRO" = "fedora" ]]; then

--- a/install-deps
+++ b/install-deps
@@ -77,6 +77,7 @@ if [[ `uname` == 'Darwin' ]]; then
 elif [[ "$(uname)" == 'Linux' ]]; then
 
     DISTRO_VERSION="$( (source /etc/os-release &>/dev/null; echo "$ID VERSION_ID") )"
+
     DISTRO="${DISTRO_VERSION%% *}" # get our distro name
     VERSION="${DISTRO_VERSION## *}" # get our version number
 
@@ -84,20 +85,20 @@ elif [[ "$(uname)" == 'Linux' ]]; then
     if [[ "$DISTRO" = "fedora" ]]; then
         distribution="fedora"
         fedora_major_version="$VERSION"
+    # Detect archlinux
     elif [[ "$DISTRO" = "arch" ]]; then
         distribution="archlinux"
+    # Detect Ubuntu
     elif [[ "$DISTRO" = "ubuntu" ]]; then
         export DEBIAN_FRONTEND=noninteractive
         distribution="ubuntu"
-        ubuntu_major_version="$VERSION"
-    elif [[ "$DISTRO" = "centos" ]]; then
-        distribution="centos"
-        centos_major_version="$VERSION"
+        ubuntu_major_version="${VERSION%%.*}"
+    # Detect CentOS
     elif [[ "$DISTRO" = "centos" ]]; then
         distribution="centos"
         centos_major_version="$VERSION"
     else
-        echo '==> Only Ubuntu, Fedora and CentOS distributions are supported.'
+        echo '==> Only Ubuntu, Fedora, Archlinux and CentOS distributions are supported.'
         exit
     fi
 

--- a/install-deps
+++ b/install-deps
@@ -76,11 +76,20 @@ if [[ `uname` == 'Darwin' ]]; then
 
 elif [[ "$(uname)" == 'Linux' ]]; then
 
-    # this will get the required information without dirtying any env state
-    DIST_VERS="$( ( . /etc/os-release &>/dev/null; echo "$ID $VERSION_ID") )"
-
-    DISTRO="${DIST_VERS%% *}" # get our distro name
-    VERSION="${DIST_VERS##* }" # get our version number
+    if [[ -r /etc/os-release ]]; then
+        # this will get the required information without dirtying any env state
+        DIST_VERS="$( ( . /etc/os-release &>/dev/null
+                        echo "$ID $VERSION_ID") )"
+        DISTRO="${DIST_VERS%% *}" # get our distro name
+        VERSION="${DIST_VERS##* }" # get our version number
+    elif [[ -r /etc/redhat-release ]]; then
+        DIST_VERS=( $( cat /etc/redhat-release ) ) # make the file an array
+        DISTRO="${DIST_VERS[0],,}" # get the first element and get lcase
+        VERS="${DIST_VERS[2]}" # get the third element (version)
+    else # well, I'm out of ideas for now
+        echo '==> Failed to determine distro and version.'
+        exit 1
+    fi
 
     # Detect fedora
     if [[ "$DISTRO" = "fedora" ]]; then

--- a/install-deps
+++ b/install-deps
@@ -74,22 +74,28 @@ if [[ `uname` == 'Darwin' ]]; then
     brew remove gnuplot
     brew install gnuplot --with-wxmac --with-cairo --with-pdflib-lite --with-x11 --without-lua
 
-elif [[ `uname` == 'Linux' ]]; then
+elif [[ "$(uname)" == 'Linux' ]]; then
+
+    DISTRO_VERSION="$( (source /etc/os-release &>/dev/null; echo "$ID VERSION_ID") )"
+    DISTRO="${DISTRO_VERSION%% *}" # get our distro name
+    VERSION="${DISTRO_VERSION## *}" # get our version number
 
     # Detect fedora
-    grep -q "ID=fedora" /etc/os-release &> /dev/null
-    if [[ "x$?" == "x0" ]]; then
-        fedora_major_version=`grep VERSION_ID /etc/os-release |cut -f2 -d"="`
+    if [[ "$DISTRO" = "fedora" ]]; then
         distribution="fedora"
-    elif (grep -q "ID=arch" /etc/os-release &> /dev/null); then
+        fedora_major_version="$VERSION"
+    elif [[ "$DISTRO" = "arch" ]]; then
         distribution="archlinux"
-    elif [[ `which apt-get` != '' ]]; then
+    elif [[ "$DISTRO" = "ubuntu" ]]; then
         export DEBIAN_FRONTEND=noninteractive
         distribution="ubuntu"
-        ubuntu_major_version=`lsb_release -a 2>&1|grep Release|cut -f2 -d":"|sed '/^$/d;s/[[:blank:]]//g' |cut -f1 -d'.'`
-    elif [[ "$(grep 'ID="centos"' /etc/os-release 2>/dev/null)" != "" ]]; then
+        ubuntu_major_version="$VERSION"
+    elif [[ "$DISTRO" = "centos" ]]; then
         distribution="centos"
-        centos_major_version=`grep VERSION_ID /etc/os-release | cut -f2 -d"=" | sed 's/"//g'`
+        centos_major_version="$VERSION"
+    elif [[ "$DISTRO" = "centos" ]]; then
+        distribution="centos"
+        centos_major_version="$VERSION"
     else
         echo '==> Only Ubuntu, Fedora and CentOS distributions are supported.'
         exit

--- a/install-deps
+++ b/install-deps
@@ -77,7 +77,7 @@ if [[ `uname` == 'Darwin' ]]; then
 elif [[ "$(uname)" == 'Linux' ]]; then
 
     # this will get the required information without dirtying any env state
-    DIST_VERS="$((source /etc/os-release &>/dev/null; echo "$ID $VERSION_ID"))"
+    DIST_VERS="$( ( . /etc/os-release &>/dev/null; echo "$ID $VERSION_ID") )"
 
     DISTRO="${DIST_VERS%% *}" # get our distro name
     VERSION="${DIST_VERS## *}" # get our version number

--- a/install-deps
+++ b/install-deps
@@ -80,7 +80,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
     DIST_VERS="$( ( . /etc/os-release &>/dev/null; echo "$ID $VERSION_ID") )"
 
     DISTRO="${DIST_VERS%% *}" # get our distro name
-    VERSION="${DIST_VERS## *}" # get our version number
+    VERSION="${DIST_VERS##* }" # get our version number
 
     # Detect fedora
     if [[ "$DISTRO" = "fedora" ]]; then


### PR DESCRIPTION
A series of changes to clean up OS detection and make it more robust and maintainable.
- subset of #51's install-deps changes with some additions
- checks /etc/os-release, /etc/redhat-release, and /etc/lsb-release for distro and version information instead of widely varying and fragile distro-specific checks
 - corrects the OS detection issue with #51 as reported in #54 
   - Travis CI is Ubuntu 12.04, but strangely lacks /etc/os-release, which appears to be part of base-files (an essential package in Ubuntu)
   - this PR has been tested with a fork of #54's reporter's CI setup
- Has been tested with Ubuntu 14.04, Ubuntu 12.04, Cent 7, and Cent 6 (unsupported and fails appropriately)
- previously, Ubuntu was detected with `which apt-get`, which would erroneously match unsupported Debian systems
 - Ubuntu is now detected using the /etc/*-release files mentioned above