### PR TITLE
install-deps: streamlined and more complete installation of deps

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -124,7 +124,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                       cmake libreadline-dev git-core libqt4-core libqt4-gui \
                       libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
                       imagemagick libzmq3-dev gfortran unzip gnuplot \
-                      gnuplot-x11 )
+                      gnuplot-x11 ipython )
         sudo apt-get update
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
@@ -180,7 +180,8 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                                 nodejs npm libjpeg-turbo-devel libpng-devel \
                                 ImageMagick GraphicsMagick-devel fftw-devel \
                                 sox-devel sox SDL2-devel zeromq3-devel \
-                                qt-devel qtwebkit-devel sox-plugins-freeworld
+                                qt-devel qtwebkit-devel sox-plugins-freeworld \
+                                ipython
             install_openblas
         else
             echo "Only Fedora 20 is supported for now, aborting."
@@ -193,7 +194,8 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                                 nodejs npm libjpeg-turbo-devel libpng-devel \
                                 ImageMagick GraphicsMagick-devel fftw-devel \
                                 sox-devel sox SDL2-devel zeromq3-devel \
-                                qt-devel qtwebkit-devel sox-plugins-freeworld
+                                qt-devel qtwebkit-devel sox-plugins-freeworld \
+                                ipython
             install_openblas
         else
             echo "Only CentOS 7 is supported for now, aborting."

--- a/install-deps
+++ b/install-deps
@@ -135,6 +135,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             sudo apt-get install -y nodejs
             sudo apt-get install -y npm
             sudo apt-get install -y libfftw3-dev sox libsox-dev libsox-fmt-all
+            sudo add-apt-repository ppa:jtaylor/ipython
         else
             sudo add-apt-repository ppa:chris-lea/zeromq
             sudo add-apt-repository ppa:chris-lea/node.js

--- a/install-deps
+++ b/install-deps
@@ -134,10 +134,10 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                 libgraphicsmagick1-dev nodejs npm libfftw3-dev sox libsox-dev \
                 libsox-fmt-all
 
-            sudo add-apt-repository ppa:jtaylor/ipython
+            sudo add-apt-repository -y ppa:jtaylor/ipython
         else
-            sudo add-apt-repository ppa:chris-lea/zeromq
-            sudo add-apt-repository ppa:chris-lea/node.js
+            sudo add-apt-repository -y ppa:chris-lea/zeromq
+            sudo add-apt-repository -y ppa:chris-lea/node.js
         fi
         sudo apt-get update
         sudo apt-get install -y "${target_pkgs[@]}"

--- a/install-deps
+++ b/install-deps
@@ -120,16 +120,17 @@ elif [[ "$(uname)" == 'Linux' ]]; then
     # Install dependencies for Torch:
     if [[ $distribution == 'ubuntu' ]]; then
         declare -a target_pkgs
-        target_pkgs=( python-software-properties build-essential gcc g++ curl \
+        target_pkgs=( build-essential gcc g++ curl \
                       cmake libreadline-dev git-core libqt4-core libqt4-gui \
                       libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
                       imagemagick libzmq3-dev gfortran unzip gnuplot \
                       gnuplot-x11 ipython )
         sudo apt-get update
+        # python-software-properties is required for apt-add-repository
+        sudo apt-get install -y python-software-properties 
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
-            sudo apt-get -y install software-properties-common
-            sudo apt-get update
+            sudo apt-get install -y software-properties-common
             sudo apt-get install -y libsdl2-dev
             sudo apt-get install -y libgraphicsmagick1-dev
             sudo apt-get install -y nodejs

--- a/install-deps
+++ b/install-deps
@@ -124,7 +124,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                       cmake libreadline-dev git-core libqt4-core libqt4-gui \
                       libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
                       imagemagick libzmq3-dev gfortran unzip gnuplot \
-                      gnuplot-x11 )
+                      gnuplot-x11 ipython )
         sudo apt-get update
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
@@ -135,7 +135,6 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             sudo apt-get install -y nodejs
             sudo apt-get install -y npm
             sudo apt-get install -y libfftw3-dev sox libsox-dev libsox-fmt-all
-            sudo apt-get install -y ipython3
         else
             sudo add-apt-repository ppa:chris-lea/zeromq
             sudo add-apt-repository ppa:chris-lea/node.js

--- a/install-deps
+++ b/install-deps
@@ -119,56 +119,28 @@ elif [[ "$(uname)" == 'Linux' ]]; then
 
     # Install dependencies for Torch:
     if [[ $distribution == 'ubuntu' ]]; then
+        declare -a target_pkgs
+        target_pkgs=( python-software-properties build-essential gcc g++ curl \
+                      cmake libreadline-dev git-core libqt4-core libqt4-gui \
+                      libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
+                      imagemagick libzmq3-dev gfortran unzip gnuplot \
+                      gnuplot-x11 )
+        sudo apt-get update
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
-            sudo apt-get update
-            sudo apt-get -y install python-software-properties
             sudo apt-get -y install software-properties-common
             sudo apt-get update
-            sudo apt-get install -y build-essential
-            sudo apt-get install -y gcc g++
-            sudo apt-get install -y cmake
-            sudo apt-get install -y curl
-            sudo apt-get install -y libreadline-dev
-            sudo apt-get install -y git-core
-            sudo apt-get install -y libqt4-core libqt4-gui libqt4-dev
-            sudo apt-get install -y libjpeg-dev
-            sudo apt-get install -y libpng-dev
-            sudo apt-get install -y ncurses-dev
-            sudo apt-get install -y imagemagick
-            sudo apt-get install -y libzmq3-dev
-            sudo apt-get install -y gfortran
-            sudo apt-get install -y unzip
-            sudo apt-get install -y gnuplot
-            sudo apt-get install -y gnuplot-x11
             sudo apt-get install -y libsdl2-dev
             sudo apt-get install -y libgraphicsmagick1-dev
             sudo apt-get install -y nodejs
             sudo apt-get install -y npm
             sudo apt-get install -y libfftw3-dev sox libsox-dev libsox-fmt-all
-            sudo apt-get update
         else
-            sudo apt-get install -y python-software-properties
             sudo add-apt-repository ppa:chris-lea/zeromq
             sudo add-apt-repository ppa:chris-lea/node.js
-            sudo apt-get update
-            sudo apt-get install -y build-essential
-            sudo apt-get install -y gcc g++
-            sudo apt-get install -y cmake
-            sudo apt-get install -y curl
-            sudo apt-get install -y libreadline-dev
-            sudo apt-get install -y git-core
-            sudo apt-get install -y libqt4-core libqt4-gui libqt4-dev
-            sudo apt-get install -y libjpeg-dev
-            sudo apt-get install -y libpng-dev
-            sudo apt-get install -y ncurses-dev
-            sudo apt-get install -y imagemagick
-            sudo apt-get install -y libzmq3-dev
-            sudo apt-get install -y gfortran
-            sudo apt-get install -y unzip
-            sudo apt-get install -y gnuplot
-            sudo apt-get install -y gnuplot-x11
         fi
+        sudo apt-get update
+        sudo apt-get install -y "${target_pkgs[@]}"
 
         install_openblas
 

--- a/install-deps
+++ b/install-deps
@@ -130,12 +130,10 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         sudo apt-get install -y python-software-properties 
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
-            sudo apt-get install -y software-properties-common
-            sudo apt-get install -y libsdl2-dev
-            sudo apt-get install -y libgraphicsmagick1-dev
-            sudo apt-get install -y nodejs
-            sudo apt-get install -y npm
-            sudo apt-get install -y libfftw3-dev sox libsox-dev libsox-fmt-all
+            sudo apt-get install -y software-properties-common libsdl2-dev \
+                libgraphicsmagick1-dev nodejs npm libfftw3-dev sox libsox-dev \
+                libsox-fmt-all
+
             sudo add-apt-repository ppa:jtaylor/ipython
         else
             sudo add-apt-repository ppa:chris-lea/zeromq

--- a/install-deps
+++ b/install-deps
@@ -195,7 +195,8 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                                 ImageMagick GraphicsMagick-devel fftw-devel \
                                 sox-devel sox SDL2-devel zeromq3-devel \
                                 qt-devel qtwebkit-devel sox-plugins-freeworld \
-                                ipython
+                                epel-release
+            sudo yum install -y python-ipython
             install_openblas
         else
             echo "Only CentOS 7 is supported for now, aborting."

--- a/install-deps
+++ b/install-deps
@@ -124,7 +124,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                       cmake libreadline-dev git-core libqt4-core libqt4-gui \
                       libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
                       imagemagick libzmq3-dev gfortran unzip gnuplot \
-                      gnuplot-x11 ipython )
+                      gnuplot-x11 )
         sudo apt-get update
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
@@ -135,6 +135,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             sudo apt-get install -y nodejs
             sudo apt-get install -y npm
             sudo apt-get install -y libfftw3-dev sox libsox-dev libsox-fmt-all
+            sudo apt-get install -y ipython3
         else
             sudo add-apt-repository ppa:chris-lea/zeromq
             sudo add-apt-repository ppa:chris-lea/node.js


### PR DESCRIPTION
Cleaned up install-deps a bit.

- have a section dedicated to installation of Ubuntu packages common between versions
- replaced repetitive apt-get calls with batched installs for cleaner code and faster installs
- install ipython on Ubuntu, Fedora, and CentOS since we check for it later
- auto-accept the addition of Ubuntu PPAs so we aren't blocking on the user pressing [enter]
- tested on Ubuntu 12.04, Ubuntu 14.04, and CentOS 7