### PR TITLE
install-deps: are we intentionally pulling from OpenBLAS/develop?

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -7,7 +7,7 @@
 install_openblas() {
     # Get and build OpenBlas (Torch is much better with a decent Blas)
     cd /tmp/
-    git clone https://github.com/xianyi/OpenBLAS.git
+    git clone https://github.com/xianyi/OpenBLAS.git -b master
     cd OpenBLAS
     if [ $(getconf _NPROCESSORS_ONLN) = 1 ]; then
         make NO_AFFINITY=1 USE_OPENMP=0 USE_THREAD=0


### PR DESCRIPTION
Are we intentionally cloning and building OpenBLAS from its development branch in install-deps?

This commit just clones the more stable 'master' branch instead of the default branch, 'develop'. If we want to stay on the bleeding edge of 'develop', that's groovy.