### PR TITLE
install-deps: exit with error value if installation fails

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -56,7 +56,7 @@ if [[ `uname` == 'Darwin' ]]; then
     # GCC?
     if [[ `which gcc` == '' ]]; then
         echo "MacOS doesn't come with GCC: please install XCode and the command line tools."
-        exit
+        exit 1
     fi
 
     # Install Homebrew (pkg manager):
@@ -114,7 +114,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         centos_major_version="$VERSION"
     else
         echo '==> Only Ubuntu, Fedora, Archlinux and CentOS distributions are supported.'
-        exit
+        exit 1
     fi
 
     # Install dependencies for Torch:
@@ -185,7 +185,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             install_openblas
         else
             echo "Only Fedora 20 is supported for now, aborting."
-            exit
+            exit 1
         fi
     elif [[ $distribution == 'centos' ]]; then
         if [[ $centos_major_version == '7' ]]; then
@@ -200,14 +200,14 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             install_openblas
         else
             echo "Only CentOS 7 is supported for now, aborting."
-            exit
+            exit 1
         fi
     fi
 
 else
     # Unsupported
     echo '==> platform not supported, aborting'
-    exit
+    exit 1
 fi
 
 ipython_exists=$(command -v ipython)


### PR DESCRIPTION
Currently, most `exit` calls in `install-deps` are responses to error states, yet most of those statements end up returning 0, indicating success.

We should return something non-zero if we have to bail out of `install-deps` so the calling script can act on the failure.

For example, if I were to run `install-all` on a Solaris machine right now, `install-deps` would lose its mind and scream about an unsupported system, `install-all` would ignore its cries, and then `install-luajit+torch` would bravely attempt to install Torch lacking unknown numbers of dependencies on a completely unsupported platform.

This change will at least make `install-all` throw a warning to the user.