### PR TITLE
Friendlier install-all

### DIFF
--- a/install-all
+++ b/install-all
@@ -51,14 +51,16 @@ function INFO()
     TPUT sgr0
 }
 
-DEPS_URL="https://raw.githubusercontent.com/torch/ezinstall/master/install-deps"
-TORCH_URL="https://raw.githubusercontent.com/torch/ezinstall/master/install-luajit+torch"
+
+DEPS_URL="https://raw.githubusercontent.com/${_GITHUB_USER:-torch}/ezinstall/${_GITHUB_BRANCH:-master}/install-deps"
+TORCH_URL="https://raw.githubusercontent.com/${_GITHUB_USER:-torch}/ezinstall/${_GITHUB_BRANCH:-master}/install-luajit+torch"
 
 INFO "Preparing to install dependencies..."
 
 # Pull in dependencies
-if ! DEPS_SCRIPT="$( curl -s "$DEPS_URL" )"; then
-    ERROR "Failed to curl $DEPS_URL . Exitting."
+if ! DEPS_SCRIPT="$( curl -s "$DEPS_URL" )" || \
+    [[ -z "$DEPS_SCRIPT" || "$DEPS_SCRIPT" = "Not Found" ]]; then
+    ERROR "Failed to curl $DEPS_URL. Exitting."
     exit 1
 fi
 
@@ -72,8 +74,9 @@ fi
 INFO "Preparing to install torch..."
 
 # Pull in torch
-if ! TORCH_SCRIPT="$( curl -s "$TORCH_URL" )"; then
-    ERROR "Failed to curl $TORCH_URL . Exitting."
+if ! TORCH_SCRIPT="$( curl -s "$TORCH_URL" )" || \
+    [[ -z "$TORCH_SCRIPT" || "$TORCH_SCRIPT" = "Not Found" ]]; then
+    ERROR "Failed to curl $TORCH_URL. Exitting."
 fi
 
 # Install torch

--- a/install-all
+++ b/install-all
@@ -5,17 +5,82 @@
 # Install all dependencies for Torch7, then Torch7 itself.
 ######################################################################
 
-# Install dependencies
-curl -s https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash
-RET=$?; if [ $RET -ne 0 ]; then
-    echo " "
-    echo " "
-    echo "---------------------------------------------------"
-    echo "WARNING: One of the dependencies failed to install.";
-    echo "---------------------------------------------------"
-    echo " "
-    echo " "
+set -e
+
+function TPUT()
+{
+    #check for TTY and tput and redefine our existence based upon the results
+    if [[ -t 1 && -t 2 ]] && command -v "tput" >& /dev/null \
+               && tput setaf 1 >& /dev/null ; then
+        function TPUT()
+        {
+            tput "$@"
+        }
+    else
+        function TPUT() { : ; }
+    fi
+
+    #now call thy self
+    TPUT "$@"
+}
+
+function ERROR()
+{
+    TPUT setaf 1 >&2
+    while read; do
+        echo "ERROR: $REPLY"
+    done <<< "$@" >&2
+    TPUT sgr0 >&2
+}
+
+function WARN()
+{
+    TPUT setaf 3
+    while read; do
+        echo "WARN: $REPLY"
+    done <<< "$@"
+    TPUT sgr0
+}
+
+function INFO()
+{
+    TPUT setaf 2
+    while read; do
+        echo "INFO: $REPLY"
+    done <<< "$@"
+    TPUT sgr0
+}
+
+DEPS_URL="https://raw.githubusercontent.com/torch/ezinstall/master/install-deps"
+TORCH_URL="https://raw.githubusercontent.com/torch/ezinstall/master/install-luajit+torch"
+
+INFO "Preparing to install dependencies..."
+
+# Pull in dependencies
+if ! DEPS_SCRIPT="$( curl -s "$DEPS_URL" )"; then
+    ERROR "Failed to curl $DEPS_URL . Exitting."
+    exit 1
 fi
+
+# Install dependencies
+if ! echo "$DEPS_SCRIPT" | bash ; then
+    WARN "At least one of the dependencies failed to install. Continuing anyway."
+else
+    INFO "Dependencies installed successfully."
+fi
+
+INFO "Preparing to install torch..."
+
+# Pull in torch
+if ! TORCH_SCRIPT="$( curl -s "$TORCH_URL" )"; then
+    ERROR "Failed to curl $TORCH_URL . Exitting."
+fi
+
 # Install torch
-curl -s https://raw.githubusercontent.com/torch/ezinstall/master/install-luajit+torch | bash
-RET=$?; if [ $RET -ne 0 ]; then echo "Error. Exiting."; exit $RET; fi
+if ! echo "$TORCH_SCRIPT" | bash ; then
+    ERROR "Torch install returned an error. Installation may be incomplete."
+    exit 1
+else
+    INFO "Torch installed successfully."
+fi
+


### PR DESCRIPTION
`install-all` is basically friendlier for everyone.

- checks that each `curl` call succeeds before piping the script to `bash`
- ensure installation scripts exit successfully and warn or error if they do not
- devs can set the `_GITHUB_USER` and `_GITHUB_BRANCH` environment variables to override where the install scripts are `curl`'d from
- provides basically installation progress information to users