### PR TITLE
install-deps: Remove sdl deps; install EPEL on Cent earlier on

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -130,7 +130,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         sudo apt-get install -y python-software-properties 
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
-            sudo apt-get install -y software-properties-common libsdl2-dev \
+            sudo apt-get install -y software-properties-common \
                 libgraphicsmagick1-dev nodejs npm libfftw3-dev sox libsox-dev \
                 libsox-fmt-all
 
@@ -150,7 +150,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         sudo pacman -S --quiet --noconfirm \
             cmake curl readline ncurses git \
             gnuplot unzip libjpeg-turbo libpng libpng \
-            imagemagick graphicsmagick fftw sox sdl2 zeromq \
+            imagemagick graphicsmagick fftw sox zeromq \
             qt4 qtwebkit
         # if GCC is not installed yet
         (pacman -Qi gcc &>/dev/null) || \
@@ -179,7 +179,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                                 gcc-c++ gcc-gfortran git gnuplot unzip \
                                 nodejs npm libjpeg-turbo-devel libpng-devel \
                                 ImageMagick GraphicsMagick-devel fftw-devel \
-                                sox-devel sox SDL2-devel zeromq3-devel \
+                                sox-devel sox zeromq3-devel \
                                 qt-devel qtwebkit-devel sox-plugins-freeworld \
                                 ipython
             install_openblas
@@ -193,7 +193,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                                 gcc-c++ gcc-gfortran git gnuplot unzip \
                                 nodejs npm libjpeg-turbo-devel libpng-devel \
                                 ImageMagick GraphicsMagick-devel fftw-devel \
-                                sox-devel sox SDL2-devel zeromq3-devel \
+                                sox-devel sox zeromq3-devel \
                                 qt-devel qtwebkit-devel sox-plugins-freeworld \
                                 epel-release
             sudo yum install -y python-ipython

--- a/install-deps
+++ b/install-deps
@@ -189,13 +189,13 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         fi
     elif [[ $distribution == 'centos' ]]; then
         if [[ $centos_major_version == '7' ]]; then
+            sudo yum install -y epel-release # a lot of things live in EPEL
             sudo yum install -y cmake curl readline-devel ncurses-devel \
                                 gcc-c++ gcc-gfortran git gnuplot unzip \
                                 nodejs npm libjpeg-turbo-devel libpng-devel \
                                 ImageMagick GraphicsMagick-devel fftw-devel \
                                 sox-devel sox zeromq3-devel \
-                                qt-devel qtwebkit-devel sox-plugins-freeworld \
-                                epel-release
+                                qt-devel qtwebkit-devel sox-plugins-freeworld
             sudo yum install -y python-ipython
             install_openblas
         else


### PR DESCRIPTION
Per https://github.com/torch/distro/issues/16#issuecomment-113687314, SDL has been removed as it is no longer required for threads (https://github.com/torch/threads/commit/9665a4b99eed85ccfad1e03a581ff14428d6dace).

Pretty much completely unrelated, EPEL is now added before we install CentOS packages. Certain dependencies live in EPEL and were not being installed if EPEL was not already enabled on the system.