### PR TITLE
iTorch requires openssl on MacOS

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -67,7 +67,7 @@ if [[ `uname` == 'Darwin' ]]; then
     # Install dependencies:
     brew update
     brew install git readline cmake wget qt
-    brew install libjpeg imagemagick zeromq graphicsmagick
+    brew install libjpeg imagemagick zeromq graphicsmagick openssl
     brew link readline --force
     brew install caskroom/cask/brew-cask
     brew cask install xquartz


### PR DESCRIPTION
Currently the install process fails for me on MacOS. This PR, in combination with another on torch/distro should fix the problem.