### PR TITLE
Wrap scripts with { } to avoid piping incomplete scripts to shell

### DIFF
--- a/install-all
+++ b/install-all
@@ -4,6 +4,7 @@
 # Complete install:
 # Install all dependencies for Torch7, then Torch7 itself.
 ######################################################################
+{
 
 set -e
 
@@ -87,3 +88,4 @@ else
     INFO "Torch installed successfully."
 fi
 
+}

--- a/install-deps
+++ b/install-deps
@@ -3,6 +3,7 @@
 ######################################################################
 # This script installs required dependencies for Torch7
 ######################################################################
+{
 
 install_openblas() {
     # Get and build OpenBlas (Torch is much better with a decent Blas)
@@ -231,3 +232,4 @@ if [[ $ipython_exists ]]; then {
 # Done.
 echo "==> Torch7's dependencies have been installed"
 
+}

--- a/install-luajit+torch
+++ b/install-luajit+torch
@@ -17,6 +17,7 @@
 #    > require 'json'
 #
 ######################################################################
+{
 
 # Prefix:
 PREFIX=${PREFIX-/usr/local}
@@ -155,3 +156,5 @@ echo "    - optim     : " $optim
 echo "    - cjson     : " $cjson
 echo "    - trepl     : " $trepl
 echo ""
+
+}


### PR DESCRIPTION
Prevents the potential problem of piping an incomplete script to the shell due to, say, a network interruption, as described [here](https://www.seancassidy.me/dont-pipe-to-your-shell.html).