### PR TITLE
install-deps: Add --needed to pacman avoid reinstalls

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -147,7 +147,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
     elif [[ $distribution == 'archlinux' ]]; then
         echo "Archlinux installation"
         chekupdates_archlinux
-        sudo pacman -S --quiet --noconfirm \
+        sudo pacman -S --quiet --noconfirm --needed \
             cmake curl readline ncurses git \
             gnuplot unzip libjpeg-turbo libpng libpng \
             imagemagick graphicsmagick fftw sox zeromq \


### PR DESCRIPTION
By default pacman will reinstall packages that already exist.  The `--needed` flag is needed to suppress this behavior.