### PR TITLE
Update install-deps.

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -31,7 +31,7 @@ install_openblas() {
 install_openblas_AUR() {
     # build and install an OpenBLAS package for Archlinux
     cd /tmp && \
-    curl https://aur.archlinux.org/packages/op/openblas-lapack/openblas-lapack.tar.gz | tar zxf - && \
+    curl https://aur.archlinux.org/cgit/aur.git/snapshot/openblas-lapack.tar.gz | tar zxf - && \
     cd openblas-lapack
     makepkg -csi --noconfirm
     RET=$?;
@@ -223,7 +223,7 @@ fi
 ipython_exists=$(command -v ipython)
 if [[ $ipython_exists ]]; then {
     ipython_version=$(ipython --version|cut -f1 -d'.')
-    if [[ $ipython_version != 2 && $ipython_version != 3 ]]; then {
+    if [[ $ipython_version != 2 && $ipython_version != 3 && $ipython_version != 4 ]]; then {
         echo 'WARNING: Your ipython version is too old.  Type "ipython --version" to see this.  Should be at least version 2'
     } fi
 } fi


### PR DESCRIPTION
 - The old URL for the openblas-lapack AUR package was 404ing
 - ipython 4.0 is now out