### PR TITLE
Install GCC 4.9 on Ubuntu.

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -149,7 +149,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                             cut -c 1)
         if [[ $gcc_major_version == '5' ]]; then
             echo '==> Found GCC 5, installing GCC 4.9.'
-            sudo apt-get install -y gcc-4.9 libgfortran-4.9-dev
+            sudo apt-get install -y gcc-4.9 libgfortran-4.9-dev g++-4.9
         fi
 
         sudo apt-get update

--- a/install-deps
+++ b/install-deps
@@ -144,6 +144,14 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             sudo add-apt-repository -y ppa:chris-lea/zeromq
             sudo add-apt-repository -y ppa:chris-lea/node.js
         fi
+
+        gcc_major_version=$(gcc --version | grep ^gcc | awk '{print $4}' | \
+                            cut -c 1)
+        if [[ $gcc_major_version == '5' ]]; then
+            echo '==> Found GCC 5, installing GCC 4.9.'
+            sudo apt-get install -y gcc-4.9 libgfortran-4.9-dev
+        fi
+
         sudo apt-get update
         sudo apt-get install -y "${target_pkgs[@]}"
 


### PR DESCRIPTION
With the Ubuntu 15.10 release, the system GCC has been updated to 5.2.1, which isn't compatible with torch.

This installs the proper version of gcc as a prerequisite, as well as libgfortran.

Updates to use this compiler in the torch build process are forthcoming.