### PR TITLE
fix multi-threaded openblas compilation

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -10,7 +10,7 @@ install_openblas() {
     cd /tmp/
     git clone https://github.com/xianyi/OpenBLAS.git
     cd OpenBLAS
-    if [ $(getconf _NPROCESSORS_ONLN) = 1 ]; then
+    if [ $(getconf _NPROCESSORS_ONLN) == 1 ]; then
         make NO_AFFINITY=1 USE_OPENMP=0 USE_THREAD=0
     else
         make NO_AFFINITY=1 USE_OPENMP=1


### PR DESCRIPTION
A small mistake in the install-deps script (assignment instead of compare) makes openblas compile always without multi-threading support.

This is a fix.