### PR TITLE
Adds support for elementary OS

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -113,12 +113,17 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         export DEBIAN_FRONTEND=noninteractive
         distribution="ubuntu"
         ubuntu_major_version="${VERSION%%.*}"
+    # Detect elementary OS
+    elif [[ "$DISTRO" = "elementary" ]]; then
+        export DEBIAN_FRONTEND=noninteractive
+        distribution="elementary"
+        elementary_version="${VERSION%.*}"
     # Detect CentOS
     elif [[ "$DISTRO" = "centos" ]]; then
         distribution="centos"
         centos_major_version="$VERSION"
     else
-        echo '==> Only Ubuntu, Fedora, Archlinux and CentOS distributions are supported.'
+        echo '==> Only Ubuntu, elementary OS, Fedora, Archlinux and CentOS distributions are supported.'
         exit 1
     fi
 
@@ -135,6 +140,32 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         sudo apt-get install -y python-software-properties 
         if [[ $ubuntu_major_version == '14' ]]; then
             echo '==> Found Ubuntu version 14.xx, installing dependencies'
+            sudo apt-get install -y software-properties-common \
+                libgraphicsmagick1-dev nodejs npm libfftw3-dev sox libsox-dev \
+                libsox-fmt-all
+
+            sudo add-apt-repository -y ppa:jtaylor/ipython
+        else
+            sudo add-apt-repository -y ppa:chris-lea/zeromq
+            sudo add-apt-repository -y ppa:chris-lea/node.js
+        fi
+        sudo apt-get update
+        sudo apt-get install -y "${target_pkgs[@]}"
+
+        install_openblas
+
+    elif [[ $distribution == 'elementary' ]]; then
+        declare -a target_pkgs
+        target_pkgs=( build-essential gcc g++ curl \
+                      cmake libreadline-dev git-core libqt4-core libqt4-gui \
+                      libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
+                      imagemagick libzmq3-dev gfortran unzip gnuplot \
+                      gnuplot-x11 ipython )
+        sudo apt-get update
+        # python-software-properties is required for apt-add-repository
+        sudo apt-get install -y python-software-properties
+        if [[ $elementary_version == '0.3' ]]; then
+            echo '==> Found Ubuntu version 14.xx based elementary installation, installing dependencies'
             sudo apt-get install -y software-properties-common \
                 libgraphicsmagick1-dev nodejs npm libfftw3-dev sox libsox-dev \
                 libsox-fmt-all


### PR DESCRIPTION
elementary OS is build on Ubuntu version and thus can be directly supported by reusing the installation code for Ubuntu.

* Version 0.3.* of elementary OS is based on Ubuntu 14.xx