### PR TITLE
Make install-deps die on errors

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 ######################################################################
 # This script installs required dependencies for Torch7
@@ -8,6 +9,7 @@
 install_openblas() {
     # Get and build OpenBlas (Torch is much better with a decent Blas)
     cd /tmp/
+    rm -rf OpenBLAS
     git clone https://github.com/xianyi/OpenBLAS.git
     cd OpenBLAS
     if [ $(getconf _NPROCESSORS_ONLN) == 1 ]; then


### PR DESCRIPTION
It seems to me that this script should have a `set -e` at the top.

> Every script should use set -e or check the exit status of every command.
https://www.debian.org/doc/debian-policy/ch-files.html#s-scripts

I've only tested this on Ubuntu - there are bound to be more errors on other platforms.