### PR TITLE
Install openblas with a deb package on Ubuntu

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -142,16 +142,19 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         sudo apt-get update
         # python-software-properties is required for apt-add-repository
         sudo apt-get install -y python-software-properties
-        if [[ $ubuntu_major_version == '14' ]]; then
-            echo '==> Found Ubuntu version 14.xx, installing dependencies'
+        echo "==> Found Ubuntu version ${ubuntu_major_version}.xx"
+        if [[ $ubuntu_major_version -lt '12' ]]; then
+            echo '==> Ubuntu version not supported.'
+            exit 1
+        elif [[ $ubuntu_major_version -lt '14' ]]; then
+            sudo add-apt-repository -y ppa:chris-lea/zeromq
+            sudo add-apt-repository -y ppa:chris-lea/node.js
+        else
             sudo apt-get install -y software-properties-common \
                 libgraphicsmagick1-dev nodejs npm libfftw3-dev sox libsox-dev \
                 libsox-fmt-all
 
             sudo add-apt-repository -y ppa:jtaylor/ipython
-        else
-            sudo add-apt-repository -y ppa:chris-lea/zeromq
-            sudo add-apt-repository -y ppa:chris-lea/node.js
         fi
 
         gcc_major_version=$(gcc --version | grep ^gcc | awk '{print $4}' | \

--- a/install-deps
+++ b/install-deps
@@ -133,12 +133,6 @@ elif [[ "$(uname)" == 'Linux' ]]; then
 
     # Install dependencies for Torch:
     if [[ $distribution == 'ubuntu' ]]; then
-        declare -a target_pkgs
-        target_pkgs=( build-essential gcc g++ curl \
-                      cmake libreadline-dev git-core libqt4-core libqt4-gui \
-                      libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
-                      imagemagick libzmq3-dev gfortran unzip gnuplot \
-                      gnuplot-x11 ipython )
         sudo apt-get update
         # python-software-properties is required for apt-add-repository
         sudo apt-get install -y python-software-properties
@@ -165,7 +159,11 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         fi
 
         sudo apt-get update
-        sudo apt-get install -y "${target_pkgs[@]}"
+        sudo apt-get install -y build-essential gcc g++ curl \
+            cmake libreadline-dev git-core libqt4-core libqt4-gui \
+            libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
+            imagemagick libzmq3-dev gfortran unzip gnuplot \
+            gnuplot-x11 ipython
 
         install_openblas
 

--- a/install-deps
+++ b/install-deps
@@ -165,7 +165,12 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             imagemagick libzmq3-dev gfortran unzip gnuplot \
             gnuplot-x11 ipython
 
-        install_openblas
+        if [[ $ubuntu_major_version -lt '14' ]]; then
+            # Install from source after installing git and build-essential
+            install_openblas
+        else
+            sudo apt-get install -y libopenblas-dev liblapack-dev
+        fi
 
     elif [[ $distribution == 'elementary' ]]; then
         declare -a target_pkgs


### PR DESCRIPTION
Why not use the [`libopenblas-dev`](http://packages.ubuntu.com/source/trusty/openblas) package available on Ubuntu to install OpenBLAS?

* Did some other refactoring that's not strictly necessary
* See commit note about installing `liblapack-dev` as well

Tested on Ubuntu 12.04 and 14.04.