### PR TITLE
Updated package names for libqtcore4 and libqtgui4

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -162,7 +162,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
 
         sudo apt-get update
         sudo apt-get install -y build-essential gcc g++ curl \
-            cmake libreadline-dev git-core libqt4-core libqt4-gui \
+            cmake libreadline-dev git-core libqtcore4 libqtgui4 \
             libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
             imagemagick libzmq3-dev gfortran unzip gnuplot \
             gnuplot-x11 ipython


### PR DESCRIPTION
For Ubuntu packages libqt4-core and libqt4-gui are called libqtcore4 and libqtgui4 now. When using the latest version of Ubuntu, this script errors out because of this.